### PR TITLE
Generate QR codes for cylinders under supplier

### DIFF
--- a/app/javascript/components/Admin/Cylinder/OptionsDropdown.js
+++ b/app/javascript/components/Admin/Cylinder/OptionsDropdown.js
@@ -4,6 +4,7 @@ import { IconNames } from "@blueprintjs/icons";
 import useRequest from "@ahooksjs/use-request";
 
 import { deleteCylinder } from "Apis/Admin/cylinder";
+import generateQrCodeUrl from "../generateQrCodeUrl";
 
 const DeleteButton = ({ id, supplierId, refresh }) => {
   const { run } = useRequest(deleteCylinder, {
@@ -21,10 +22,6 @@ const DeleteButton = ({ id, supplierId, refresh }) => {
 };
 
 export default function OptionsDropdown({ id, supplierId, refresh }) {
-  const generateQRCodePage = () => {
-    return `${window.location.origin}/oxygen/vendors/${supplierId}/qr_codes?ids=${id}`;
-  };
-
   return (
     <Popover2
       placement="bottom-end"
@@ -33,7 +30,7 @@ export default function OptionsDropdown({ id, supplierId, refresh }) {
           <MenuItem
             icon={IconNames.DOCUMENT_SHARE}
             text="Generate QR Code"
-            href={generateQRCodePage()}
+            href={generateQrCodeUrl(supplierId, [id])}
             target="_blank"
           />
           <DeleteButton id={id} supplierId={supplierId} refresh={refresh} />

--- a/app/javascript/components/Admin/Supplier/AddCylinder.js
+++ b/app/javascript/components/Admin/Supplier/AddCylinder.js
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import { useForm, useFieldArray } from "react-hook-form";
 import { Icon } from "@blueprintjs/core";
+import { useHistory, useParams } from "react-router";
 
+import { addCylinders } from "Apis/Admin/supplier";
 import useQuery from "Hooks/useQuery";
 import Input from "Common/Form/Input";
 import Button from "Common/Button";
-import { addCylinders } from "Apis/Admin/supplier";
 import {
   CylinderStatus,
   CylinderCapacity,
@@ -13,7 +14,7 @@ import {
 } from "Common/CustomFields";
 
 import FormOutline from "./FormOutline";
-import { useHistory, useParams } from "react-router";
+import generateQrCodeUrl from "../generateQrCodeUrl";
 
 const getDefaultValues = (urlParams) => {
   return {
@@ -51,12 +52,7 @@ function AddCylinder() {
     try {
       const response = await addCylinders(id, data);
       const ids = response.map(({ id }) => id);
-      window.open(
-        `${window.location.origin}/oxygen/vendors/${id}/qr_codes?ids=${ids.join(
-          ","
-        )}`,
-        "_blank"
-      );
+      window.open(generateQrCodeUrl(id, ids), "_blank");
       history.push("/admin/suppliers");
     } catch (err) {
       console.error(err);

--- a/app/javascript/components/Admin/Supplier/OptionsDropdown.js
+++ b/app/javascript/components/Admin/Supplier/OptionsDropdown.js
@@ -4,6 +4,7 @@ import { IconNames } from "@blueprintjs/icons";
 import useRequest from "@ahooksjs/use-request";
 
 import { deleteSupplier } from "Apis/Admin/supplier";
+import generateQrCodeUrl from "../generateQrCodeUrl";
 
 const DeleteButton = ({ id, refresh }) => {
   const { run } = useRequest(deleteSupplier, {
@@ -20,12 +21,18 @@ const DeleteButton = ({ id, refresh }) => {
   );
 };
 
-export default function OptionsDropdown({ id, refresh }) {
+export default function OptionsDropdown({ id, cylinderIds, refresh }) {
   return (
     <Popover2
       placement="bottom-end"
       content={
         <Menu className={Classes.ELEVATION_1}>
+          <MenuItem
+            icon={IconNames.DOCUMENT_SHARE}
+            text="Generate QR Codes"
+            href={generateQrCodeUrl(id, cylinderIds)}
+            target="_blank"
+          />
           <DeleteButton id={id} refresh={refresh} />
         </Menu>
       }

--- a/app/javascript/components/Admin/Supplier/SupplierList.js
+++ b/app/javascript/components/Admin/Supplier/SupplierList.js
@@ -65,7 +65,15 @@ function SupplierList() {
         Header: "",
         width: 0,
         Cell: function Options({ row: { original } }) {
-          return <OptionsDropdown id={original.id} refresh={refresh} />;
+          const { cylinders } = original;
+          const cylinderIds = cylinders.map(({ id }) => id);
+          return (
+            <OptionsDropdown
+              id={original.id}
+              cylinderIds={cylinderIds}
+              refresh={refresh}
+            />
+          );
         },
       },
     ],

--- a/app/javascript/components/Admin/generateQrCodeUrl.js
+++ b/app/javascript/components/Admin/generateQrCodeUrl.js
@@ -1,0 +1,12 @@
+/**
+ * Generate QR Code link
+ * @param {string} supplierId ID of supplier
+ * @param {string[]} ids IDs of cylinders
+ */
+function generateQrCodeUrl(supplierId, ids) {
+  return `${
+    window.location.origin
+  }/oxygen/vendors/${supplierId}/qr_codes?ids=${ids.join(",")}`;
+}
+
+export default generateQrCodeUrl;


### PR DESCRIPTION
- move URL generation to a util function
- QR codes can now be generated on add, individual cylinder, all cylinders under a supplier